### PR TITLE
Add fire_replaced_class_double.

### DIFF
--- a/lib/rspec/fire.rb
+++ b/lib/rspec/fire.rb
@@ -201,7 +201,8 @@ module RSpec
           klass.const_set(name, Module.new)
         end
 
-        @__resetter = lambda { deepest_defined_const.send(:remove_const, remaining_parts.first) }
+        const_to_remove = remaining_parts.first || const_name
+        @__resetter = lambda { deepest_defined_const.send(:remove_const, const_to_remove) }
         context.const_set(const_name, self)
       end
     end

--- a/lib/rspec/fire.rb
+++ b/lib/rspec/fire.rb
@@ -175,7 +175,8 @@ module RSpec
         end
 
         def stub!
-          *context_parts, @const_name = @full_constant_name.split('::')
+          context_parts = @full_constant_name.split('::')
+          @const_name = context_parts.pop
           @context = recursive_const_get(context_parts.join('::'))
           @original_value = @context.send(:remove_const, @const_name)
           @context.const_set(@const_name, @stubbed_value)
@@ -202,7 +203,8 @@ module RSpec
         end
 
         def stub!
-          *context_parts, const_name = @full_constant_name.split('::')
+          context_parts = @full_constant_name.split('::')
+          const_name = context_parts.pop
 
           remaining_parts = context_parts.dup
           @deepest_defined_const = context_parts.inject(Object) do |klass, name|

--- a/lib/rspec/fire.rb
+++ b/lib/rspec/fire.rb
@@ -182,12 +182,16 @@ module RSpec
         end
 
         def rspec_reset
-          @context.send(:remove_const, @const_name)
-          @context.const_set(@const_name, @original_value)
+          if recursive_const_get(@full_constant_name).equal?(@stubbed_value)
+            @context.send(:remove_const, @const_name)
+            @context.const_set(@const_name, @original_value)
+          end
         end
       end
 
       class UndefinedConstantSetter
+        include RecursiveConstMethods
+
         def initialize(full_constant_name, stubbed_value)
           @full_constant_name = full_constant_name
           @stubbed_value      = stubbed_value
@@ -216,7 +220,9 @@ module RSpec
         end
 
         def rspec_reset
-          @deepest_defined_const.send(:remove_const, @const_to_remove)
+          if recursive_const_get(@full_constant_name).equal?(@stubbed_value)
+            @deepest_defined_const.send(:remove_const, @const_to_remove)
+          end
         end
       end
 

--- a/lib/rspec/fire.rb
+++ b/lib/rspec/fire.rb
@@ -5,11 +5,11 @@ require 'delegate'
 module RSpec
   module Fire
     module RecursiveConstMethods
-      def recursive_const_get object, name
+      def recursive_const_get name
         name.split('::').inject(Object) {|klass,name| klass.const_get name }
       end
 
-      def recursive_const_defined? object, name
+      def recursive_const_defined? name
         !!name.split('::').inject(Object) {|klass,name|
           if klass && klass.const_defined?(name)
             klass.const_get name
@@ -97,8 +97,8 @@ module RSpec
       end
 
       def with_doubled_class
-        if recursive_const_defined?(Object, @__doubled_class_name)
-          yield recursive_const_get(Object, @__doubled_class_name)
+        if recursive_const_defined?(@__doubled_class_name)
+          yield recursive_const_get(@__doubled_class_name)
         end
       end
 
@@ -176,7 +176,7 @@ module RSpec
 
         def stub!
           *context_parts, @const_name = @full_constant_name.split('::')
-          @context = recursive_const_get(Object, context_parts.join('::'))
+          @context = recursive_const_get(context_parts.join('::'))
           @original_value = @context.send(:remove_const, @const_name)
           @context.const_set(@const_name, @stubbed_value)
         end
@@ -221,7 +221,7 @@ module RSpec
       end
 
       def self.stub!(constant_name, value)
-        stubber = if recursive_const_defined?(Object, constant_name)
+        stubber = if recursive_const_defined?(constant_name)
           DefinedConstantReplacer.new(constant_name, value)
         else
           UndefinedConstantSetter.new(constant_name, value)

--- a/spec/fire_double_spec.rb
+++ b/spec/fire_double_spec.rb
@@ -15,7 +15,6 @@ class TestObject
 end
 
 class TestClass
-  VALUE = 7
   extend TestMethods
 
   class Nested

--- a/spec/fire_double_spec.rb
+++ b/spec/fire_double_spec.rb
@@ -172,7 +172,7 @@ shared_examples_for "loaded constant stubbing" do |const_name|
   include RSpec::Fire::RecursiveConstMethods
 
   define_method :const do
-    recursive_const_get(Object, const_name)
+    recursive_const_get(const_name)
   end
 
   it 'allows it to be stubbed' do
@@ -198,10 +198,10 @@ end
 
 shared_examples_for "unloaded constant stubbing" do |const_name|
   include RSpec::Fire::RecursiveConstMethods
-  before { recursive_const_defined?(Object, const_name).should be_false }
+  before { recursive_const_defined?(const_name).should be_false }
 
   define_method :const do
-    recursive_const_get(Object, const_name)
+    recursive_const_get(const_name)
   end
 
   it 'allows it to be stubbed' do
@@ -212,7 +212,7 @@ shared_examples_for "unloaded constant stubbing" do |const_name|
   it 'removes the constant when rspec clears its mocks' do
     stub_const(const_name, 7)
     reset_rspec_mocks
-    recursive_const_defined?(Object, const_name).should be_false
+    recursive_const_defined?(const_name).should be_false
   end
 
   it 'returns nil since it was not originally set' do

--- a/spec/fire_double_spec.rb
+++ b/spec/fire_double_spec.rb
@@ -325,7 +325,7 @@ describe "#stub_const" do
     it 'removes the first unloaded constant but leaves the loaded nested constant when rspec resets its mocks' do
       defined?(TestClass::Nested::NestedEvenMore).should be_true
       defined?(TestClass::Nested::NestedEvenMore::X).should be_false
-      stub_const("TestClass::Nested::NestedEvenMore", 7)
+      stub_const("TestClass::Nested::NestedEvenMore::X::Y::Z", 7)
       reset_rspec_mocks
       defined?(TestClass::Nested::NestedEvenMore).should be_true
       defined?(TestClass::Nested::NestedEvenMore::X).should be_false

--- a/spec/fire_double_spec.rb
+++ b/spec/fire_double_spec.rb
@@ -203,6 +203,14 @@ describe '#fire_replaced_class_double (for a non-existant class)' do
     defined?(A).should be_false
   end
 
+  it 'handles a single, unnested undefined constant' do
+    defined?(Goo).should be_false
+    double = fire_replaced_class_double("Goo")
+    Goo.should be(double)
+    reset_double(double)
+    defined?(Goo).should be_false
+  end
+
   it 'handles constants with some nestings that are set' do
     defined?(TestClass::Nested).should be_true
     defined?(TestClass::Nested::X::Y::Z).should be_false


### PR DESCRIPTION
fire_replaced_class_double is like fire_class_double, plus it temporarily replaces the named constant with itself.  This is handy when the code-under-test references the named constant.  The double also registers itself with rspec-mocks space to ensure it gets reset after each example.  When it is reset it ensures all constants are as they originally were.
