### PR TITLE
Transfer nested constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.gem
+spec/gemfiles/*.lock

--- a/lib/rspec/fire.rb
+++ b/lib/rspec/fire.rb
@@ -28,6 +28,7 @@ module RSpec
         @double             = double
         @method_finder      = method_finder
         @backing            = backing
+        @sym = backing.respond_to?(:sym) ? @backing.sym : @backing.message
         super(backing)
       end
 
@@ -51,7 +52,7 @@ module RSpec
 
       def ensure_arity(actual)
         @double.with_doubled_class do |klass|
-          klass.send(@method_finder, sym).should have_arity(actual)
+          klass.send(@method_finder, @sym).should have_arity(actual)
         end
       end
 

--- a/lib/rspec/fire.rb
+++ b/lib/rspec/fire.rb
@@ -142,13 +142,17 @@ module RSpec
     end
 
     class FireClassDoubleBuilder
-      def self.build(doubled_class, *args)
+      def self.build(doubled_class, stubs = {})
         Module.new do
           extend FireDoublable
 
           @__doubled_class_name = doubled_class
           @__checked_methods = :public_methods
           @__method_finder   = :method
+
+          stubs.each do |message, response|
+            stub(message).and_return(response)
+          end
 
           def self.as_replaced_constant(options = {})
             @__original_class = ConstantStubber.stub!(@__doubled_class_name, self, options)

--- a/lib/rspec/fire.rb
+++ b/lib/rspec/fire.rb
@@ -234,6 +234,7 @@ module RSpec
           end
 
           if @transfer_nested_constants.is_a?(Array)
+            @transfer_nested_constants = @transfer_nested_constants.map(&:to_s) if RUBY_VERSION == '1.8.7'
             undefined_constants = @transfer_nested_constants - @original_value.constants
 
             if undefined_constants.any?

--- a/lib/rspec/fire.rb
+++ b/lib/rspec/fire.rb
@@ -155,6 +155,10 @@ module RSpec
             extend AsReplacedConstant
             self
           end
+
+          def self.to_s
+            @__doubled_class_name + " (fire double)"
+          end
         end
       end
 

--- a/lib/rspec/fire.rb
+++ b/lib/rspec/fire.rb
@@ -159,6 +159,10 @@ module RSpec
           def self.to_s
             @__doubled_class_name + " (fire double)"
           end
+
+          def self.name
+            @__doubled_class_name
+          end
         end
       end
 

--- a/lib/rspec/fire.rb
+++ b/lib/rspec/fire.rb
@@ -149,8 +149,8 @@ module RSpec
           @__checked_methods = :public_methods
           @__method_finder   = :method
 
-          def self.as_replaced_constant
-            @__original_class = ConstantStubber.stub!(@__doubled_class_name, self)
+          def self.as_replaced_constant(options = {})
+            @__original_class = ConstantStubber.stub!(@__doubled_class_name, self, options)
             extend AsReplacedConstant
             self
           end

--- a/lib/rspec/fire.rb
+++ b/lib/rspec/fire.rb
@@ -163,6 +163,10 @@ module RSpec
           def self.name
             @__doubled_class_name
           end
+
+          def self.method_missing(name, *args)
+            __mock_proxy.raise_unexpected_message_error(name, *args)
+          end
         end
       end
 

--- a/spec/fire_double_spec.rb
+++ b/spec/fire_double_spec.rb
@@ -2,6 +2,14 @@ require 'spec_helper'
 
 TOP_LEVEL_VALUE_CONST = 7
 
+RSpec::Mocks::Space.class_eval do
+  # Deal with the fact that #mocks was renamed to #receivers for RSpec 2.9:
+  # https://github.com/rspec/rspec-mocks/commit/17c259ea5143d309e90ca6d53d40f6356ac2d0a5
+  unless private_instance_methods.include?(:receivers)
+    alias_method :receivers, :mocks
+  end
+end
+
 module TestMethods
   def defined_method
     raise "Y U NO MOCK?"
@@ -267,7 +275,7 @@ shared_examples_for "unloaded constant stubbing" do |const_name|
   it 'does not remove the constant when the example manually sets it' do
     begin
       stub_const(const_name, 7)
-      stubber = RSpec::Mocks.space.send(:mocks).first
+      stubber = RSpec::Mocks.space.send(:receivers).first
       change_const_value_to(new_const_value = Object.new)
       reset_rspec_mocks
       const.should equal(new_const_value)

--- a/spec/fire_double_spec.rb
+++ b/spec/fire_double_spec.rb
@@ -139,6 +139,10 @@ describe '#fire_class_double' do
   let(:doubled_object) { fire_class_double("TestClass") }
 
   it_should_behave_like 'a fire-enhanced double'
+
+  it 'uses a module for the doubled object so that it supports nested constants like a real class' do
+    doubled_object.should be_a(Module)
+  end
 end
 
 def reset_rspec_mocks

--- a/spec/fire_double_spec.rb
+++ b/spec/fire_double_spec.rb
@@ -166,6 +166,12 @@ describe '#fire_replaced_class_double (for an existing class)' do
     reset_rspec_mocks
     TestClass.should be(orig_class)
   end
+
+  it 'supports transferring nested constants to the double' do
+    fire_class_double("TestClass").as_replaced_constant(:transfer_nested_constants => true)
+    TestClass::M.should eq(:m)
+    TestClass::N.should eq(:n)
+  end
 end
 
 describe '#fire_replaced_class_double (for a non-existant class)' do

--- a/spec/fire_double_spec.rb
+++ b/spec/fire_double_spec.rb
@@ -172,6 +172,12 @@ describe '#fire_class_double' do
       doubled_object.abc
     }.to raise_error(RSpec::Mocks::MockExpectationError)
   end
+
+  it 'allows stubs to be specified as a hash' do
+    double = fire_class_double("SomeClass", :a => 5, :b => 8)
+    double.a.should eq(5)
+    double.b.should eq(8)
+  end
 end
 
 def reset_rspec_mocks

--- a/spec/fire_double_spec.rb
+++ b/spec/fire_double_spec.rb
@@ -166,6 +166,12 @@ describe '#fire_class_double' do
     TestClass.name.should eq("TestClass")
     doubled_object.name.should eq("TestClass")
   end
+
+  it 'raises a mock expectation error for undefind methods' do
+    expect {
+      doubled_object.abc
+    }.to raise_error(RSpec::Mocks::MockExpectationError)
+  end
 end
 
 def reset_rspec_mocks

--- a/spec/fire_double_spec.rb
+++ b/spec/fire_double_spec.rb
@@ -161,6 +161,11 @@ describe '#fire_class_double' do
     doubled_object.to_s.should include("TestClass (fire double)")
     doubled_object.inspect.should include("TestClass (fire double)")
   end
+
+  it 'assigns the class name' do
+    TestClass.name.should eq("TestClass")
+    doubled_object.name.should eq("TestClass")
+  end
 end
 
 def reset_rspec_mocks

--- a/spec/fire_double_spec.rb
+++ b/spec/fire_double_spec.rb
@@ -156,6 +156,11 @@ describe '#fire_class_double' do
   it 'uses a module for the doubled object so that it supports nested constants like a real class' do
     doubled_object.should be_a(Module)
   end
+
+  it 'has a readable string representation' do
+    doubled_object.to_s.should include("TestClass (fire double)")
+    doubled_object.inspect.should include("TestClass (fire double)")
+  end
 end
 
 def reset_rspec_mocks

--- a/spec/gemfiles/rspec-latest
+++ b/spec/gemfiles/rspec-latest
@@ -1,5 +1,5 @@
 source :rubygems
 
-gem 'rspec'
+gem 'rspec', '~> 2.9.0.rc2'
 
 gemspec :path => '../../'


### PR DESCRIPTION
This is a followup to #4.
- This switches `fire_class_double` to use a module rather than a subclass of `RSpec::Mocks::Mock`. The reason for the change is to allow class doubles to have nested constants like real classes and modules.  I was surprised at how seamless this change was.  I think we do lose a couple things in this change, though:
  - There's not the `:__declared_as` entry in the mock options hash that rspec uses as part of its error message.  This isn't a big deal to me, though.
  - RSpec mocks support additional options when declared that aren't supported here.  Besides some deprecated things (like `:null_object => true`), I think rspec treats an options hash as a list of methods-to-stub and corresponding values.  It wouldn't be hard to add that here.
- I decided to not transfer constants by default.  I like the flexibility of being able to either have it transfer all nested constants (`:transfer_nested_constants => true`) or specify a list of constants to transfer (`:transfer_nested_constants => [:A, :B])`.  The APIs were more natural and readable this way then trying to do the inverse, I think.
- There are a few edge cases I had to think carefully about and decide what to do for.  I decided to raise errors for several of these, but I can be convinced otherwise.  Specifically, here are the cases that cause it to raise an error:
  - When `stub_const` is called with a `:transfer_nested_constants` option and the named constant is not a class or module.  The original object doesn't have any constants to transfer then.
  - When `stub_const` is called with a `:transfer_nested_constants` option and the given stub object is not a class or module.  The constants cannot be transferred to it then.
  - When a list of constants is used (`:transfer_nested_constants => [:A]`) but one or more of those are not defined constants.  I can see an argument either way on this one (especially given rspec-fire's use case of being used with as little loaded as possible), but I felt like putting a constant in the whitelist implies it is an important constant that you always want to be transferred, and thus an error to notify you that the constant is undefined is helpful.  In most cases, I would expect this to happen due to fat-fingering a constant name.
- Currently, constant transferring isn't supported when using `fire_replaced_class_double`.  Instead you have to use `fire_class_double("ClassName").as_replaced_constant(:transfer_nested_constants =>  true)`.  I felt like it would be confusing to support the option directly on `fire_replaced_class_double` since it accepts a hash of options that are intended to be test double options.  The `:transfer_nested_constants` option is specific to the constant stubbing and felt like it belonged there to keep things simpler.  This suggests to me that maybe `fire_class_double("...").as_replaced_constant` is the right interface for this.
- I noticed that the rspec-fire was broken against the just-released rspec 2.9.0.rc2, so I fixed that as well.

Feedback welcome, of course.

/cc @freelancing-god
