### PR TITLE
Use new TestDouble module to make class doubles true test doubles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ rvm:
 gemfile:
   - spec/gemfiles/rspec25
   - spec/gemfiles/rspec-latest
+  - spec/gemfiles/rspec-master

--- a/lib/rspec/fire.rb
+++ b/lib/rspec/fire.rb
@@ -150,8 +150,17 @@ module RSpec
           @__checked_methods = :public_methods
           @__method_finder   = :method
 
-          stubs.each do |message, response|
-            stub(message).and_return(response)
+          if defined?(::RSpec::Mocks::TestDouble)
+            ::RSpec::Mocks::TestDouble.extend_onto self,
+              doubled_class, stubs.merge(:__declared_as => "FireClassDouble")
+          else
+            stubs.each do |message, response|
+              stub(message).and_return(response)
+            end
+
+            def self.method_missing(name, *args)
+              __mock_proxy.raise_unexpected_message_error(name, *args)
+            end
           end
 
           def self.as_replaced_constant(options = {})
@@ -170,10 +179,6 @@ module RSpec
 
           def self.name
             @__doubled_class_name
-          end
-
-          def self.method_missing(name, *args)
-            __mock_proxy.raise_unexpected_message_error(name, *args)
           end
         end
       end

--- a/spec/fire_double_spec.rb
+++ b/spec/fire_double_spec.rb
@@ -1,5 +1,8 @@
 require 'spec_helper'
 
+def use; end
+private :use
+
 TOP_LEVEL_VALUE_CONST = 7
 
 RSpec::Mocks::Space.class_eval do
@@ -33,6 +36,10 @@ class TestClass
   class Nested
     class NestedEvenMore
     end
+  end
+
+  def self.use
+    raise "Y U NO MOCK?"
   end
 end
 
@@ -178,6 +185,16 @@ describe '#fire_class_double' do
     double.a.should eq(5)
     double.b.should eq(8)
   end
+
+  it 'allows private methods to be stubbed, just like on a normal test double (but unlike a partial mock)' do
+    mod = Module.new
+    mod.stub(:use)
+    expect { mod.use }.to raise_error(/private method `use' called/)
+
+    fire_double = fire_class_double("TestClass")
+    fire_double.stub(:use)
+    fire_double.use # should not raise an error
+  end if defined?(::RSpec::Mocks::TestDouble)
 end
 
 def reset_rspec_mocks

--- a/spec/gemfiles/rspec-master
+++ b/spec/gemfiles/rspec-master
@@ -1,0 +1,6 @@
+source :rubygems
+
+gem 'rspec'
+gem 'rspec-mocks', :git => 'git://github.com/rspec/rspec-mocks.git'
+
+gemspec :path => '../../'


### PR DESCRIPTION
rspec-mocks treat true test doubles a bit different than partial mocks.  One difference is that on a pure mock object, it makes any stubbed or mocked method public.  On a partial mock, it doesn't change the method visibility.

I was using a fire_class_double on a project that also loaded sinatra.  The class I was using the double in place of had a public `#use` method, but sinatra adds a private `#use` method (for middleware) to the top-level object, and this caused my test to fail in a very surprising way.  It took me a bit to track it back to the source (i.e. the fact that with my recent changes to use a module for a fire_class_double, RSpec no longer treated it as a pure mock).  You can see an example of this bug [here](https://gist.github.com/2042094).

I've just [committed a change](https://github.com/rspec/rspec-mocks/commit/af3f296ed24b25cb014b3e0b1afa9f0e90db8635) to rspec-mocks to extract the code from `RSpec::Mocks::Mock` into a module (`RSpec::Mocks::TestDouble`).  This is the corresponding change here to extend our class double modules with this module so that rspec treats it as a pure mock object.

Let me know if you have any questions.
