### PR TITLE
Allow `fire_double("Class", :foo => 17)` syntax.

### DIFF
--- a/lib/rspec/fire.rb
+++ b/lib/rspec/fire.rb
@@ -178,9 +178,11 @@ module RSpec
 
         # __declared_as copied from rspec/mocks definition of `double`
         args.last[:__declared_as] = 'FireDouble'
-        super
+
         @__checked_methods = :public_instance_methods
         @__method_finder   = :instance_method
+
+        super
       end
     end
 

--- a/spec/fire_double_spec.rb
+++ b/spec/fire_double_spec.rb
@@ -153,6 +153,11 @@ describe '#fire_double' do
   let(:doubled_object) { fire_double("TestObject") }
 
   it_should_behave_like 'a fire-enhanced double'
+
+  it 'allows stubs to be passed as a hash' do
+    double = fire_double("TestObject", :defined_method => 17)
+    double.defined_method.should eq(17)
+  end
 end
 
 describe '#fire_class_double' do


### PR DESCRIPTION
The ivars @__checked_methods and @__method_finder must be set before supering, so that when the superclass initializer calls #stub with each given message, the implementation can be checked.  Previously, you would get a 'nil is not a symbol' error.
