### PR TITLE
Don't count block params when determining the max arity.

### DIFF
--- a/lib/rspec/fire.rb
+++ b/lib/rspec/fire.rb
@@ -29,7 +29,7 @@ module RSpec
         def max_arity
           params = method.parameters
           return INFINITY if params.any? { |(type, name)| type == :rest } # splat
-          params.size
+          params.count { |(type, name)| type != :block }
         end
       else
         # On 1.8, Method#parameters does not exist.

--- a/spec/fire_double_spec.rb
+++ b/spec/fire_double_spec.rb
@@ -551,4 +551,18 @@ describe RSpec::Fire::SupportArityMatcher do
       }.to raise_error(/Expected 1 or more, got 0/)
     end
   end
+
+  context "a method with an explicit block arg" do
+    def m(a, &b); end
+
+    it 'passes when given 1' do
+      method(:m).should support_arity(1)
+    end
+
+    it 'fails when given 2' do
+      expect {
+        method(:m).should support_arity(2)
+      }.to raise_error(/Expected 1, got 2/)
+    end
+  end
 end


### PR DESCRIPTION
Before this change, the following worked improperly:

``` ruby
  class A
    def m(a, &b)
    end
  end

  fire_double("A").stub(:m).with(:two, :arguments)
```

The block arg was counted previously so this passed even though it should not.
