### PR TITLE
Add verify_constant_names config option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,22 @@ Particularly handy for `ActiveRecord` finders. Use `fire_class_double`. If you
 dig into the code, you'll find you can create subclasses of `FireDouble` to
 check for *any* set of methods.
 
+### Preventing Typo'd Constant Names
+
+`fire_double("MyClas")` will not verify any mocked methods, even when
+`MyClass` is loaded, because of the typo in the constant name. There's
+an option to help prevent these sorts of fat-finger errors:
+
+    RSpec::Fire.configure do |config|
+      config.verify_constant_names = true
+    end
+
+When this is set to true, rspec-fire will raise an error when given
+the name of an undefined constant. You probably only want to set this
+when running your entire test suite, with all production code loaded.
+Setting this for an isolated unit test will prevent you from being
+able to isolate it!
+
 ### Mocking Done Right (tm)
 
 * Only mock methods on collaborators, _not_ the class under test.


### PR DESCRIPTION
When this is set to true, an error will be raised if a given constant name is undefined.

This is the idea I had in #16.

If you like this, it'd be great to get it in the next release.  If you have any concerns, feel free to hold off for now--I'd rather get a rspec-2.11-compatible release out sooner (I have a few projects I won't be able to upgrade rspec on until there's a corresponding rspec-fire release).
