### PR TITLE
Handle strings as well as symbols for method stubs.

### DIFF
--- a/lib/rspec/fire.rb
+++ b/lib/rspec/fire.rb
@@ -177,7 +177,7 @@ module RSpec
       end
 
       def unimplemented_methods(doubled_class, expected_methods, checked_methods)
-        expected_methods -
+        expected_methods.map(&:to_sym) -
           implemented_methods(doubled_class, checked_methods)
       end
 

--- a/spec/fire_double_spec.rb
+++ b/spec/fire_double_spec.rb
@@ -58,11 +58,14 @@ shared_examples_for 'a fire-enhanced double method' do
   describe 'doubled class is not loaded' do
     let(:doubled_object) { fire_double("UnloadedObject") }
     should_allow(:undefined_method)
+    should_allow('undefined_method')
   end
 
   describe 'doubled class is loaded' do
     should_allow(:defined_method)
+    should_allow('defined_method')
     should_not_allow(:undefined_method)
+    should_not_allow('undefined_method')
   end
 end
 


### PR DESCRIPTION
Yes, I usually write my method stubs using symbols, but wandered from that path with some simple metaprogramming. RSpec's fine with strings, but rspec-fire wasn't when it came to running my full test suite - it insisted the methods did not exist on the real classes.

Perhaps the implementation's not quite right, or the tests don't need to happen everywhere - I leave that to your tweaking, given you know your code better than I.
