### PR TITLE
Fix use of const_get/const_defined? to handle undefined consts like Foo::Hash

### DIFF
--- a/spec/fire_double_spec.rb
+++ b/spec/fire_double_spec.rb
@@ -193,6 +193,12 @@ describe '#fire_double' do
     double = fire_double("TestObject", :defined_method => 17)
     double.defined_method.should eq(17)
   end
+
+  it 'does not prevent stubbing methods on an unloaded nested constant with a name that matches a top-level constant' do
+    double = fire_double("TestObject::Hash")
+    double.stub(:foo).and_return("bar")
+    double.foo.should eq("bar")
+  end
 end
 
 describe '#fire_class_double' do


### PR DESCRIPTION
When you name a nested constant that ends in a name that matches a top-level constant (such as "Foo::Hash"), rspec-fire was verifying the presence of a stubbed method on ::Hash if "Foo::Hash" was not defined. 1.9's const_get/const_defined? accepts a flag argument to have it ignore inherited/top-level constants, but 1.8 doesn't accept this argument, so we have to conditionally define methods to handle this properly.

@xaviershay -- we were just bit by this bug. It'd be nice to get an official release with this fix out soonish--let me know if I can help with that.
