### PR TITLE
Make things work for projects that disable the `should` syntax.

### DIFF
--- a/lib/rspec/fire.rb
+++ b/lib/rspec/fire.rb
@@ -159,9 +159,13 @@ module RSpec
 
       protected
 
+      def expect(value)
+        ::RSpec::Expectations::ExpectationTarget.new(value)
+      end
+
       def ensure_arity(actual)
         @double.with_doubled_class do |klass|
-          klass.__send__(@method_finder, @sym).should support_arity(actual)
+          expect(klass.__send__(@method_finder, @sym)).to support_arity(actual)
         end
       end
 

--- a/spec/fire_double_spec.rb
+++ b/spec/fire_double_spec.rb
@@ -203,6 +203,24 @@ describe '#fire_double' do
     double.stub(:foo).and_return("bar")
     double.foo.should eq("bar")
   end
+
+  def with_isolated_syntax_change
+    original_syntax = ::RSpec::Matchers.configuration.syntax
+    yield
+  ensure
+    ::RSpec::Matchers.configuration.syntax = original_syntax
+  end
+
+  it 'works when the `should` syntax is disabled' do
+    with_isolated_syntax_change do
+      ::RSpec::Matchers.configuration.syntax = :expect
+      expect(5).not_to respond_to(:should, :should_not)
+
+      double = fire_double("TestObject")
+      double.should_receive(:defined_method_one_arg).with(8)
+      double.defined_method_one_arg(8)
+    end
+  end
 end
 
 describe '#fire_class_double' do


### PR DESCRIPTION
I ran into this issue when converting one of my projects to the new `expect` syntax.

I can merge this, but I wanted to give @xaviershay a chance to review first.
